### PR TITLE
chore: run gofmt on several files

### DIFF
--- a/cmd/encode.go
+++ b/cmd/encode.go
@@ -5,9 +5,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
 	"github.com/aryansharma9917/codewise-cli/pkg/encoder"
 	"github.com/aryansharma9917/codewise-cli/pkg/prompt"
+	"github.com/spf13/cobra"
 )
 
 var (

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,8 +1,8 @@
 package cmd
 
 import (
-	"github.com/spf13/cobra"
 	"github.com/aryansharma9917/codewise-cli/pkg/generator"
+	"github.com/spf13/cobra"
 )
 
 var (

--- a/cmd/template.go
+++ b/cmd/template.go
@@ -1,8 +1,8 @@
 package cmd
 
 import (
-	"github.com/spf13/cobra"
 	"github.com/aryansharma9917/codewise-cli/pkg/generator"
+	"github.com/spf13/cobra"
 )
 
 var (

--- a/pkg/encoder/base64.go
+++ b/pkg/encoder/base64.go
@@ -33,6 +33,5 @@ func Base64Decode(inputFile, outputFile string) error {
 // echo "hello codewise" > input.txt
 // go run main.go encode --base64 --input=input.txt --output=encoded.txt
 
-
 // go run main.go encode --base64 --decode --input=encoded.txt --output=output.txt
 // cat output.txt  # => hello codewise

--- a/pkg/encoder/yaml_to_json.go
+++ b/pkg/encoder/yaml_to_json.go
@@ -31,7 +31,6 @@ func YAMLToJSON(inputFile, outputFile string) error {
 	return nil
 }
 
-
 // Example usage:
 // apiVersion: v1
 // kind: Pod


### PR DESCRIPTION
Run `gofmt -w` on a handful of files to normalize formatting.

Files formatted:
- `cmd/encode.go`
- `cmd/init.go`
- `cmd/template.go`
- `pkg/encoder/base64.go`
- `pkg/encoder/yaml_to_json.go`
